### PR TITLE
Fix expectation which fails locally with color enabled terminals

### DIFF
--- a/tests/testthat/test-str.R
+++ b/tests/testthat/test-str.R
@@ -57,7 +57,7 @@ test_that("authors are printed to the screen properly", {
 
   expect_output(
     print(desc),
-    "Authors@R (parsed):
+    "(parsed):
     * Hadley Wickham <h.wickham@gmail.com> [aut, cre, cph]
     * Peter Danenberg <pcd@roxygen.org> [aut, cph]
     * Manuel Eugster [aut, cph]


### PR DESCRIPTION
E.g. running `devtools::test()` this fails because Authors@R is has ANSI
escapes for the color blue around it.

The easiest fix is to exclude Authors@R from the string to be matched.