### PR TITLE
Re-encode fields if necessary

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -1,7 +1,7 @@
 
 ## TODO: handle empty files
 
-read_dcf <- function(file) {
+read_dcf <- function(file, encoding = "") {
   lines <- readLines(file)
   no_tws_fields <- sub(
     ":$",
@@ -27,9 +27,36 @@ read_dcf <- function(file) {
   }
 
   notws <- res[1, match(no_tws_fields, fields)]
-
+  res <- re_encode(as.list(res[1, ]), encoding)
   list(
-    dcf = create_fields(fields, res[1, ]),
+    dcf = create_fields(fields, res),
     notws = notws
   )
+}
+
+# From https://github.com/wch/r-source/blob/93b33adbcecd4a2577e1d5b873bef9a52fd734b8/src/library/utils/R/indices.R#L76
+re_encode <- function(desc, encoding = "") {
+  enc <- desc[["Encoding"]]
+  if(!is.null(enc) && !is.na(encoding)) {
+    ## Determine encoding and re-encode if necessary and possible.
+    if (missing(encoding) && Sys.getlocale("LC_CTYPE") == "C")
+      encoding <- "ASCII//TRANSLIT"
+    if(encoding != enc) { # try to translate from 'enc' to 'encoding' --------
+      ## might have an invalid encoding ...
+      newdesc <- try(lapply(desc, iconv, from = enc, to = encoding))
+    dOk <- function(nd) !inherits(nd, "error") && !anyNA(nd)
+    ok <- dOk(newdesc)
+    if(!ok) # try again
+      ok <- dOk(newdesc <- try(lapply(desc, iconv, from = enc,
+            to = paste0(encoding,"//TRANSLIT"))))
+    if(!ok) # try again
+      ok <- dOk(newdesc <- try(lapply(desc, iconv, from = enc,
+            to = "ASCII//TRANSLIT", sub = "?")))
+    if(ok)
+      desc <- newdesc
+    else
+      warning("'DESCRIPTION' file has an 'Encoding' field and re-encoding is not possible", call. = FALSE)
+    }
+  }
+  desc
 }

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,5 +1,9 @@
 # devel
 
+* If a DESCRIPTION field uses an `Encoding:` field that differs from the
+  sessions encoding, the fields are now converted to the sessions encoding if
+  possible, (#52, @jimhester).
+
 * add `get_built()` function to parse the Built field used in package binaries.
   (#48, @jimhester)
 

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -39,3 +39,22 @@ test_that("Unset Encoding results warning", {
   expect_warning(desc$set(Author = "Gábor Csárdi"), "Encoding")
 
 })
+
+test_that("different encoding is converted", {
+
+  expect_silent(
+    desc <- description$new(
+      text = paste0(
+        "Package: foo\n",
+        "Title: Foo Package\n",
+        "Author: Package Author\n",
+        "Maintainer: G\xE1bor Cs\xE1rdi <author@here.net>\n",
+        "Description: The great foo package.\n",
+        "License: GPL\n",
+        "Encoding: latin1\n"
+        )
+      )
+    )
+
+  expect_silent(desc$set(Author = "Gábor Csárdi"))
+})


### PR DESCRIPTION
If the declared encoding differs from the session encoding, we need to
try and re-encode the fields to the session encoding using iconv.

Fixes #52 

I am not sure of a great way to test the re-encoding succeeded properly, so suggestions welcome there. I also do not know if we should expose the `encoding` parameter to the user in some way...

Also the code comes from R, so we could rewrite it in some fashion, not sure how it would effect the package license.