### PR TITLE
Account for non-URL content in the URL field

### DIFF
--- a/R/urls.R
+++ b/R/urls.R
@@ -1,6 +1,7 @@
 
 parse_urls <- function(urls) {
-  str_trim(strsplit(urls, "[,\\s]+", perl = TRUE)[[1]])
+  out <- str_trim(strsplit(str_trim(urls), "[,\\s]+", perl = TRUE)[[1]])
+  grep("^http", out, value = TRUE)
 }
 
 deparse_urls <- function(urls) {

--- a/desc.Rproj
+++ b/desc.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/D8
+++ b/tests/testthat/D8
@@ -1,0 +1,31 @@
+Package: hunspell
+Type: Package
+Title: High-Performance Stemmer, Tokenizer, and Spell Checker
+Version: 2.9
+Depends: R (>= 3.0.2)
+Encoding: UTF-8
+Authors@R: c(
+    person("Jeroen", "Ooms", ,"jeroen@berkeley.edu", role = c("aut", "cre")),
+    person("Authors of libhunspell", role = "cph", comment = "see AUTHORS file"))
+Description: Low level spell checker and morphological analyzer based on the
+    famous 'hunspell' library <https://hunspell.github.io>. The package can analyze
+    or check individual words as well as parse text, latex, html or xml documents.
+    For a more user-friendly interface use the 'spelling' package which builds on
+    this package to automate checking of files, documentation and vignettes in all
+    common formats.
+License: GPL-2 | LGPL-2.1 | MPL-1.1
+URL:
+    https://github.com/ropensci/hunspell#readme (devel)
+    https://hunspell.github.io (upstream)
+BugReports: https://github.com/ropensci/hunspell/issues
+Imports: Rcpp, digest
+LinkingTo: Rcpp (>= 0.12.12)
+Suggests: spelling,
+    testthat,
+    pdftools,
+    janeaustenr,
+    wordcloud2,
+    knitr,
+    rmarkdown
+VignetteBuilder: knitr
+RoxygenNote: 6.0.1.9000

--- a/tests/testthat/test-urls.R
+++ b/tests/testthat/test-urls.R
@@ -29,3 +29,12 @@ test_that("get, set, etc. urls", {
   expect_identical(desc$get_urls(), character())
   expect_identical(desc$get("URL"), c(URL = NA_character_))
 })
+
+test_that("leading newlines and embedded descriptors are ignored", {
+  desc <- description$new("D8")
+  expect_identical(
+    desc$get_urls(),
+    c("https://github.com/ropensci/hunspell#readme",
+      "https://hunspell.github.io")
+  )
+})


### PR DESCRIPTION
Fixes #56 desc_get_urls() doesn't account for some real-world phenomena