### PR TITLE
Fix text inputs with marked encodings

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -721,7 +721,7 @@ idesc_create_file <- function(self, private, file) {
 
 idesc_create_text <- function(self, private, text) {
   assert_that(is.character(text))
-  con <- textConnection(text, local = TRUE)
+  con <- textConnection(text, local = TRUE, encoding = "bytes")
   on.exit(close(con), add = TRUE)
   dcf <- read_dcf(con)
   private$notws <- dcf$notws

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,8 @@
 
+* When using `desc(text=)` parameter, set `textConnection(encoding =
+  "bytes")` to handle cases when the input text is in a different marked
+  encoding than the default encoding, such as UTF-8 input on Windows.
+
 # 1.2.0
 
 * Add `get_field()` method, with easier to use failure and fallback

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -60,6 +60,26 @@ test_that("different encoding is converted to UTF-8 when reading", {
   expect_silent(desc$set(Author = "G\u00e1bor Cs\u00e1rdi"))
 })
 
+test_that("handles case when text is marked with a non-default locale", {
+
+  expect_silent(
+    desc <- description$new(
+      text = enc2utf8(paste0(
+        "Package: foo\n",
+        "Title: Foo Package\n",
+        "Author: Package Author\n",
+        "Maintainer: G\u00e1bor Cs\u00e1rdi <author@here.net>\n",
+        "Description: The great foo package.\n",
+        "License: GPL\n",
+        "Encoding: UTF-8\n"
+      ))
+    )
+  )
+
+  expect_equal(Encoding(desc$get("Maintainer")), "UTF-8")
+  expect_silent(desc$set(Author = "G\u00e1bor Cs\u00e1rdi"))
+})
+
 test_that("encoding is converted to specified when writing", {
 
   desc <- description$new(


### PR DESCRIPTION
If `desc()` was called with a text parameter and the input was _not_ in
the default encoding for the locale `textConnection()` would be called
with the default encoding parameter of `""`, which attempts to convert
the encoding to the default one. Using encoding = "bytes" means the
connection does not try to convert the encoding and just passes the
bytes through unchanged, which fixes the issue.