### PR TITLE
make it possible to add an author with a comment including e.g. an ORCID

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -23,8 +23,8 @@ is_character <- function(x) {
 
 is_named_character_or_null <- function(x){
   is.null(x) ||
-    is.character(x) && length(x) == 1 ||
-    is.character(x) && length(names(x)) == length(x)
+    is.character(x) && length(x) == 1 && !is.na(x) ||
+    is.character(x) && length(names(x)) == length(x) && all(!is.na(x))
 
 }
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -21,12 +21,11 @@ is_character <- function(x) {
   is.character(x) && all(! is.na(x))
 }
 
-is_named_character <- function(x){
-  if(length(x) == 1){
-    is_character(x)
-  }else{
-    is_character(x) && length(names(x)) == length(x)
-  }
+is_named_character_or_null <- function(x){
+  is.null(x) ||
+    is.character(x) && length(x) == 1 ||
+    is.character(x) && length(names(x)) == length(x)
+
 }
 
 on_failure(is_character) <- function(call, env) {
@@ -85,9 +84,6 @@ is_string_or_null <- function(x) {
   is_string(x) || is.null(x)
 }
 
-is_named_character_or_null <- function(x) {
-  is_named_character(x) || is.null(x)
-}
 
 on_failure(is_string_or_null) <- function(call, env) {
   paste0(deparse(call$x), " must be a string or NULL")

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -28,7 +28,7 @@ is_named_character_or_null <- function(x){
 
 }
 
-on_failure(is_character) <- function(call, env) {
+on_failure(is_named_character_or_null) <- function(call, env) {
   paste0(deparse(call$x), " is not a named character vector")
 }
 

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -15,6 +15,24 @@ on_failure(is_string) <- function(call, env) {
   paste0(deparse(call$x), " is not a string")
 }
 
+# Comment can be either a single string
+# or a named vector of strings
+is_character <- function(x) {
+  is.character(x) && all(! is.na(x))
+}
+
+is_named_character <- function(x){
+  if(length(x) == 1){
+    is_character(x)
+  }else{
+    is_character(x) && length(names(x)) == length(x)
+  }
+}
+
+on_failure(is_character) <- function(call, env) {
+  paste0(deparse(call$x), " is not a named character vector")
+}
+
 is_constructor_cmd <- function(x) {
   is_string(x) && substring(x, 1, 1) == "!"
 }
@@ -65,6 +83,10 @@ on_failure(is_authors) <- function(call, env) {
 
 is_string_or_null <- function(x) {
   is_string(x) || is.null(x)
+}
+
+is_named_character_or_null <- function(x) {
+  is_named_character(x) || is.null(x)
 }
 
 on_failure(is_string_or_null) <- function(call, env) {

--- a/R/authors-at-r.R
+++ b/R/authors-at-r.R
@@ -104,7 +104,7 @@ check_author_args <- function(given = NULL, family = NULL, email = NULL,
     is_string_or_null(family),
     is_string_or_null(email),
     is_string_or_null(role),
-    is_string_or_null(comment)
+    is_named_character_or_null(comment)
   )
 }
 

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -23,6 +23,10 @@ test_that("is_named_character_or_null", {
          comment2 = "comment")
   expect_true(is_named_character_or_null(x))
 
+  x <- c(comment1 = "comment1",
+         comment2 = NA)
+  expect_false(is_named_character_or_null(x))
+
 
   x <- NULL
   expect_true(is_named_character_or_null(x))

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -9,18 +9,22 @@ test_that("is_existing_file", {
   )
 })
 
-test_that("is_named_character", {
+test_that("is_named_character_or_null", {
   x <- c(2, 3)
-  expect_false(is_named_character(x))
+  expect_false(is_named_character_or_null(x))
 
   x <- "comment"
-  expect_true(is_named_character(x))
+  expect_true(is_named_character_or_null(x))
 
   x <- c("comment1", "comment")
-  expect_false(is_named_character(x))
+  expect_false(is_named_character_or_null(x))
 
   x <- c(comment1 = "comment1",
          comment2 = "comment")
-  expect_true(is_named_character(x))
+  expect_true(is_named_character_or_null(x))
+
+
+  x <- NULL
+  expect_true(is_named_character_or_null(x))
 })
 

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -8,3 +8,19 @@ test_that("is_existing_file", {
     expect_error(desc::desc(miss), paste0(miss, ".*does not exist"))
   )
 })
+
+test_that("is_named_character", {
+  x <- c(2, 3)
+  expect_false(is_named_character(x))
+
+  x <- "comment"
+  expect_true(is_named_character(x))
+
+  x <- c("comment1", "comment")
+  expect_false(is_named_character(x))
+
+  x <- c(comment1 = "comment1",
+         comment2 = "comment")
+  expect_true(is_named_character(x))
+})
+

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -65,7 +65,7 @@ test_that("we cannot add an author with malformatted comment", {
   expect_error(desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
                   role = "ctb",
                   comment = c(ORCID = "orcid_number", what=NA)),
-               "comment is_not")
+               "comment is not")
 
 
 })

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -58,6 +58,18 @@ test_that("we can add an author with ORCID", {
   )
 })
 
+test_that("we cannot add an author with malformatted comment", {
+
+  desc <- description$new(cmd = "!new")
+
+  expect_error(desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+                  role = "ctb",
+                  comment = c(ORCID = "orcid_number", what=NA)),
+               "comment is_not")
+
+
+})
+
 test_that("we can search for authors", {
   desc <- description$new("D2")
   authors <- desc$get_authors()

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -36,6 +36,15 @@ test_that("we can add an author", {
     format(desc$get_authors()[5]),
     "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?)"
   )
+})
+
+test_that("we can add an author with ORCID", {
+
+  R_version <- paste(R.version$major,
+                   R.version$minor,
+                   sep = ".")
+
+  skip_if_not(R_version >= "3.5.0")
 
   desc <- description$new(cmd = "!new")
 

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -36,6 +36,17 @@ test_that("we can add an author", {
     format(desc$get_authors()[5]),
     "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?)"
   )
+
+  desc <- description$new(cmd = "!new")
+
+  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+                  role = "ctb",
+                  comment = c(ORCID = "orcid_number", what="he did it"))
+
+  expect_identical(
+    format(desc$get_authors()[2]),
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (<https://orcid.org/orcid_number>, he did it)"
+  )
 })
 
 test_that("we can search for authors", {


### PR DESCRIPTION
cf #65 (in preparation for the PR I intend to do for #63 )

One thing I wasn't sure about is whether you can add anything to the comment field, or whether there's a limited number of named strings that can go in there. I wasn't able to find that in "Writing R extensions" (where the ORCID support isn't documented yet anyway).