### PR TITLE
Preserve ordering of dependencies

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -15,7 +15,6 @@ is_ascii <- function(x) {
   )
 }
 
-
 ## This is from tools/R/QC.R
 ## We do not calculate code coverage for this, as
 ## it is run at install time

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,5 @@
+* `desc_set_deps()` now inserts new packages in alphabetical order, if the existing packages are already in alphabetical order
+
 * New `add_author_gh()` method and `desc_add_author_gh()` function to add an author using the information available from GitHub V3 API. This method and function depend on `gh` and are limited when the GitHub user fullname is incomplete or not well parsed by `as.person()` and when their email address isn't available. (@maelle, #71)
 
 * When using `desc_normalize()` the package dependencies are now alphabetically 

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -16,14 +16,14 @@ test_that("get_deps", {
 
 
 test_that("set_dep", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   desc$set_dep("igraph")
 
   res <- data.frame(
     stringsAsFactors = FALSE,
     type = c("Imports", "Imports", "Suggests"),
-    package = c("R6", "igraph", "testthat"),
+    package = c("igraph", "R6", "testthat"),
     version = c("*", "*", "*")
   )
   expect_equal(desc$get_deps(), res)
@@ -33,8 +33,8 @@ test_that("set_dep", {
   res <- data.frame(
     stringsAsFactors = FALSE,
     type = c("Imports", "Imports", "Suggests"),
-    package = c("R6", "igraph", "testthat"),
-    version = c("*", ">= 1.0.0", "*")
+    package = c("igraph", "R6", "testthat"),
+    version = c(">= 1.0.0", "*", "*")
   )
 
   expect_equal(desc$get_deps(), res)
@@ -44,8 +44,8 @@ test_that("set_dep", {
   res <- data.frame(
     stringsAsFactors = FALSE,
     type = c("Imports", "Imports", "Suggests", "Depends"),
-    package = c("R6", "igraph", "testthat", "igraph"),
-    version = c("*", ">= 1.0.0", "*", ">= 1.0.0")
+    package = c("igraph", "R6", "testthat", "igraph"),
+    version = c(">= 1.0.0", "*", "*", ">= 1.0.0")
   )
 
   expect_equal(desc$get_deps(), res)
@@ -67,6 +67,39 @@ test_that("set_dep for the first dependency", {
     version = c("*")
   )
   expect_equal(desc$get_deps(), res)
+})
+
+test_that("set_dep preserves order", {
+  desc <- description$new("!new")
+
+  desc$set_deps(data.frame(
+    stringsAsFactors = FALSE,
+    type = "Imports",
+    package = c("covr", "testthat"),
+    version = "*"
+  ))
+  desc$set_dep("R6", "Imports")
+
+  expect_equal(
+    desc$get_deps()$package,
+    c("covr", "R6", "testthat")
+  )
+})
+test_that("set_dep inserts at end if not ordered", {
+  desc <- description$new("!new")
+
+  desc$set_deps(data.frame(
+    stringsAsFactors = FALSE,
+    type = "Imports",
+    package = c("testthat", "covr"),
+    version = "*"
+  ))
+  desc$set_dep("R6", "Imports")
+
+  expect_equal(
+    desc$get_deps()$package,
+    c("testthat", "covr", "R6")
+  )
 })
 
 test_that("del_dep", {


### PR DESCRIPTION
(If they're ordered)

The logic is complicated, but the tests hit every line, so I'm reasonable certain it's correct.