### PR TITLE
multiple roles can be applied to each person

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -21,6 +21,14 @@ is_character <- function(x) {
   is.character(x) && all(! is.na(x))
 }
 
+is_character_or_null <- function(x){
+  is.null(x) || is_character(x)
+}
+
+on_failure(is_character_or_null) <- function(call, env) {
+  paste0(deparse(call$x), " is not a character vector")
+}
+
 is_named_character_or_null <- function(x){
   is.null(x) ||
     is.character(x) && length(x) == 1 && !is.na(x) ||

--- a/R/authors-at-r.R
+++ b/R/authors-at-r.R
@@ -106,7 +106,7 @@ check_author_args <- function(given = NULL, family = NULL, email = NULL,
     is_string_or_null(given),
     is_string_or_null(family),
     is_string_or_null(email),
-    is_string_or_null(role),
+    is_character_or_null(role),
     is_named_character_or_null(comment),
     is_string_or_null(orcid)
   )


### PR DESCRIPTION
In the original implementation, multiple roles cannot be applied to role argument for functions such as desc$add_author(). This is because check_author_args() function called from add_author() calls is_string_or_null() for role argument. This checks whether the role is NULL or character vector with length of 1.
In the develop implementation for that I am creating pull request, role argument can be character vector with any length. Instead of is_string_or_null(), is_character_or_null() is implemented and used. 

The following code is allowed in this implementation.
```
desc$add_author("Bugs", "Bunny", email = "bb@example.com", role=c("ctb", "cph"))
```