### PR TITLE
Fix r cmd check

### DIFF
--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -54,7 +54,7 @@ test_that("we can add an author with ORCID via comment", {
 
   expect_identical(
     format(desc$get_authors()[2]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (<https://orcid.org/orcid_number>, he did it)"
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (orcid_number, he did it)"
   )
 })
 
@@ -75,7 +75,7 @@ test_that("we can add an author with ORCID", {
 
   expect_identical(
     format(desc$get_authors()[2]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (he did it, <https://orcid.org/orcid_number>)"
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (he did it, orcid_number)"
   )
 })
 
@@ -141,7 +141,7 @@ test_that("we can add an ORCID to an author", {
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?, <https://orcid.org/notanorcid>)"
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?, notanorcid)"
   )
 })
 
@@ -158,7 +158,7 @@ test_that("we can replace the ORCID of an author", {
 
   expect_identical(
     format(desc$get_authors()[1]),
-    "Hadley Wickham <h.wickham@gmail.com> [aut, cre, cph] (<https://orcid.org/notanorcid>)"
+    "Hadley Wickham <h.wickham@gmail.com> [aut, cre, cph] (notanorcid)"
   )
 })
 
@@ -258,7 +258,7 @@ test_that("add_me can use ORCID_ID", {
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Bugs Bunny <bugs.bunny@acme.com> [ctb] (<https://orcid.org/orcid_number>)"
+    "Bugs Bunny <bugs.bunny@acme.com> [ctb] (orcid_number)"
   )
 })
 


### PR DESCRIPTION
Because I think #85 is not properly implemented, I wanted to fix it, but I could not make R CMD check pass before or after that fix. I managed to fix some issue with ORCID (see commits) but now I am stuck. In particular, I have the following problem: 

I can make the tests in `test-deps.R` pass when ran interactively and with the 'Run Tests' Buttom in R Studio, but when testing the package with `devtools::test()` and 'Test Package' in the build tools tab, I get unexpected errors. 

```r
Loading desc
Testing desc
✓ |  OK F W S | Context
✓ |  37       | Package archives [0.3 s]
✓ |   7       | Assertions
✓ |  29       | Authors [0.5 s]
✓ |   2       | BUILT
✓ |  49       | Syntax checks [0.1 s]
✓ |  30       | Collate API [0.1 s]
✓ |  32       | Constructors [0.1 s]
x |  29 4     | Dependencies [0.3 s]
───────────────────────────────────────────────────────────────────────────
test-deps.R:29: failure: set_dep
desc$get_deps() not equal to `res`.
Component "package": 2 string mismatches

test-deps.R:40: failure: set_dep
desc$get_deps() not equal to `res`.
Component "package": 2 string mismatches
Component "version": 2 string mismatches

test-deps.R:51: failure: set_dep
desc$get_deps() not equal to `res`.
Component "package": 2 string mismatches
Component "version": 2 string mismatches

test-deps.R:83: failure: set_dep preserves order
desc$get_deps()$package not equal to c("covr", "R6", "testthat").
2/3 mismatches
x[1]: "R6"
y[1]: "covr"

x[2]: "covr"
y[2]: "R6"
───────────────────────────────────────────────────────────────────────────
✓ |   1       | desc
✓ |  11       | Encoding
✓ |   3       | Nice behavior
✓ |  32       | Non OO API [0.9 s]
✓ |  29       | Queries [0.1 s]
✓ |   9       | DCF reader
✓ |   9       | REMOTE
✓ |  10       | repair
✓ |   7       | Formatting [0.2 s]
✓ |   1       | to_latex
x |   4 1     | Absense of trailing WS is kept
───────────────────────────────────────────────────────────────────────────
test-trailing-ws.R:28: failure: WS is present in newly created files
`contents` does not match "\nAuthors@R: \n".
Actual value: "Package: \{\{ Package \}\}\\nTitle: \{\{ Title \}\}\\nVersion: 1\.0\.0\\nAuthors@R:\\n    c\(person\(given = "Jo", family = "Doe", email = "jodoe@dom\.ain",\\n      role = c\("aut", "cre"\)\)\)\\nMaintainer: \{\{ Maintainer \}\}\\nDescription: \{\{ Description \}\}\\nLicense: \{\{ License \}\}\\nLazyData: true\\nURL: \{\{ URL \}\}\\nBugReports: \{\{ BugReports \}\}\\nEncoding: UTF-8"
───────────────────────────────────────────────────────────────────────────
✓ |   9       | URL
✓ |  28       | Utility functions
✓ |   1       | Validation
✓ |  31       | Version [0.2 s]
x |   2 2     | Write [0.1 s]
───────────────────────────────────────────────────────────────────────────
test-write.R:38: failure: whitespace after : if field was updated
readLines(t1) not equal to c("Imports: ", "    one,", "    two,", "    doh").
3/4 mismatches
x[2]: "    doh,"
y[2]: "    one,"

x[3]: "    one,"
y[3]: "    two,"

x[4]: "    two"
y[4]: "    doh"

test-write.R:48: failure: whitespace after : if field was updated
readLines(t2) not equal to c("Imports:", "    one,", "    two,", "    doh").
3/4 mismatches
x[2]: "    doh,"
y[2]: "    one,"

x[3]: "    one,"
y[3]: "    two,"

x[4]: "    two"
y[4]: "    doh"
───────────────────────────────────────────────────────────────────────────

══ Results ════════════════════════════════════════════════════════════════
Duration: 3.7 s

OK:       402
Failed:   7
Warnings: 0
Skipped:  0
```
The failing tests in `test-write.R` and `test-trailing.R` also occur interactively and need to be fixed separately I think.

I also deleted all other `test-*` files  (except `test-deps.R`) to make sure no env variable or other set-up problems exist, but I still can't make `devtools::test()` and 'Test Package' from the build tab making the tests pass. 