### PR TITLE
Fix ordering of imports

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -16,12 +16,10 @@ idesc_set_dep <- function(self, private, package, type, version) {
 
     if (sorted) {
       # find first row it should come after
-      idx <- which(deps$type == type && package > deps$package)
+      idx <- which(deps$type == type & package < deps$package)
       if (length(idx) == 0) {
         # must be first
         idx <- which(deps$type == type)[[1]]
-      } else {
-        idx <- idx[[1]] + 1
       }
     } else {
       idx <- nrow(deps) + 1

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -54,7 +54,7 @@ test_that("we can add an author with ORCID via comment", {
 
   expect_identical(
     format(desc$get_authors()[2]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (<https://orcid.org/orcid_number>, he did it)"
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (orcid_number, he did it)"
   )
 })
 
@@ -75,7 +75,7 @@ test_that("we can add an author with ORCID", {
 
   expect_identical(
     format(desc$get_authors()[2]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (he did it, <https://orcid.org/orcid_number>)"
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (he did it, orcid_number)"
   )
 })
 
@@ -141,7 +141,7 @@ test_that("we can add an ORCID to an author", {
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?, <https://orcid.org/notanorcid>)"
+    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?, notanorcid)"
   )
 })
 
@@ -158,7 +158,7 @@ test_that("we can replace the ORCID of an author", {
 
   expect_identical(
     format(desc$get_authors()[1]),
-    "Hadley Wickham <h.wickham@gmail.com> [aut, cre, cph] (<https://orcid.org/notanorcid>)"
+    "Hadley Wickham <h.wickham@gmail.com> [aut, cre, cph] (notanorcid)"
   )
 })
 
@@ -258,7 +258,7 @@ test_that("add_me can use ORCID_ID", {
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Bugs Bunny <bugs.bunny@acme.com> [ctb] (<https://orcid.org/orcid_number>)"
+    "Bugs Bunny <bugs.bunny@acme.com> [ctb] (orcid_number)"
   )
 })
 

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -84,6 +84,13 @@ test_that("set_dep preserves order", {
     desc$get_deps()$package,
     c("covr", "R6", "testthat")
   )
+  desc$set_dep('styler', 'Imports')
+  expect_equal(
+    desc$get_deps()$package,
+    c("covr", "R6", 'styler', "testthat")
+  )
+
+
 })
 test_that("set_dep inserts at end if not ordered", {
   desc <- description$new("!new")


### PR DESCRIPTION
Closes #95. But let's first try to fix existing R CMD check issues as proposed in #94. 