### PR TITLE
Add param `squish_ws` to `desc_get_field()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,28 @@
 
 # Development version
 
+## Breaking changes
+
+* `desc_get_field()` gains a boolean `squish_ws` parameter to normalize
+  whitespace within the retrieved value. It defaults to the value of `trim_ws`
+  (`TRUE` by default). Example with desc's current DESCRIPTION:
+  
+  Old behaviour:
+  
+  ```r
+  > desc::desc_get_field("Description")
+  [1] "Tools to read, write, create, and manipulate DESCRIPTION files.\n    It is intended for packages that create or manipulate other packages."
+  ```
+  
+  New behaviour:
+  
+  ```r
+  > desc::desc_get_field("Description")
+  [1] "Tools to read, write, create, and manipulate DESCRIPTION files. It is intended for packages that create or manipulate other packages."
+  ```
+  
+  If you want the old behaviour, just set `squish_ws = FALSE`.
+
 # 1.3.0
 
 * Adding authors with long names or other fields (`comment`, typically)

--- a/R/description.R
+++ b/R/description.R
@@ -102,7 +102,7 @@ desc <- function(cmd = NULL, file = NULL, text = NULL, package = NULL) {
 #'
 #' The complete API reference:
 #' \preformatted{  description$get(keys)
-#'   description$get_field(key, default, trim_ws = TRUE)
+#'   description$get_field(key, default, trim_ws = TRUE, squish_ws = trim_ws)
 #'   description$set(...)
 #'   description$fields()
 #'   description$has_fields(keys)
@@ -111,8 +111,10 @@ desc <- function(cmd = NULL, file = NULL, text = NULL, package = NULL) {
 #'   \item{key:}{A character string (length one), the key to query.}
 #'   \item{default:}{If specified and \code{key} is missing, this value
 #'     is returned. If not specified, an error is thrown.}
-#'   \item{trim_ws:}{Whether to trim leading  and trailing whitespace
+#'   \item{trim_ws:}{Whether to trim leading and trailing whitespace
 #'     from the returned value.}
+#'   \item{squish_ws:}{Whether to reduce repeated whitespace in the
+#'     returned value.}
 #'   \item{keys:}{A character vector of keys to query, check or delete.}
 #'   \item{...:}{This must be either two unnamed arguments, the key and
 #'     and the value to set; or an arbitrary number of named arguments,
@@ -480,8 +482,8 @@ description <- R6Class("description",
       idesc_get(self, private, keys),
 
     get_field = function(key, default = stop("Field '", key, "' not found"),
-                         trim_ws = TRUE)
-      idesc_get_field(self, private, key, default, trim_ws),
+                         trim_ws = TRUE, squish_ws = trim_ws)
+      idesc_get_field(self, private, key, default, trim_ws, squish_ws),
 
     get_or_fail = function(keys)
       idesc_get_or_fail(self, private, keys),
@@ -835,11 +837,14 @@ idesc_get <- function(self, private, keys) {
   res
 }
 
-idesc_get_field <- function(self, private, key, default, trim_ws) {
+idesc_get_field <- function(self, private, key, default, trim_ws, squish_ws) {
   stopifnot(is_string(key))
   stopifnot(is_flag(trim_ws))
   val <- private$data[[key]]$value
-  if (trim_ws && !is.null(val)) val <- str_trim(val)
+  if (!is.null(val)) {
+    if (trim_ws) val <- str_trim(val)
+    if (squish_ws) val <- str_squish(val)
+  }
   val %||% default
 }
 

--- a/R/non-oo-api.R
+++ b/R/non-oo-api.R
@@ -103,6 +103,8 @@ desc_get <- generate_api("get", self = FALSE)
 #'   By default it throws an error.
 #' @param trim_ws Whether to trim leading and trailing whitespace
 #'   from the value. Defaults to \code{TRUE}.
+#' @param squish_ws Whether to reduce repeated whitespace in the value.
+#'   Defaults to \code{trim_ws}.
 #' @return Character string, the value of \code{key}, or \code{default}
 #'   if \code{key} is not found and \code{default} is specified.
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,6 +5,9 @@ str_trim <- function(x) {
   sub("^\\s+", "", sub("\\s+$", "", x))
 }
 
+str_squish <- function(x) {
+  gsub("\\s+", " ", x)
+}
 
 is_ascii <- function(x) {
   vapply(

--- a/man/desc_get_field.Rd
+++ b/man/desc_get_field.Rd
@@ -9,6 +9,7 @@ desc_get_field(
   key,
   default = stop("Field '", key, "' not found"),
   trim_ws = TRUE,
+  squish_ws = trim_ws,
   file = "."
 )
 
@@ -22,6 +23,9 @@ By default it throws an error.}
 
 \item{trim_ws}{Whether to trim leading and trailing whitespace
 from the value. Defaults to \code{TRUE}.}
+
+\item{squish_ws}{Whether to reduce repeated whitespace in the value.
+Defaults to \code{trim_ws}.}
 
 \item{file}{DESCRIPTION file to use. By default the DESCRIPTION
 file of the current package (i.e. the package the working directory

--- a/man/description.Rd
+++ b/man/description.Rd
@@ -80,7 +80,7 @@ if the field is not found.
 
 The complete API reference:
 \preformatted{  description$get(keys)
-  description$get_field(key, default, trim_ws = TRUE)
+  description$get_field(key, default, trim_ws = TRUE, squish_ws = trim_ws)
   description$set(...)
   description$fields()
   description$has_fields(keys)
@@ -89,8 +89,10 @@ The complete API reference:
   \item{key:}{A character string (length one), the key to query.}
   \item{default:}{If specified and \code{key} is missing, this value
     is returned. If not specified, an error is thrown.}
-  \item{trim_ws:}{Whether to trim leading  and trailing whitespace
+  \item{trim_ws:}{Whether to trim leading and trailing whitespace
     from the returned value.}
+  \item{squish_ws:}{Whether to reduce repeated whitespace in the
+    returned value.}
   \item{keys:}{A character vector of keys to query, check or delete.}
   \item{...:}{This must be either two unnamed arguments, the key and
     and the value to set; or an arbitrary number of named arguments,


### PR DESCRIPTION
This cleans the returned value from any repeated whitespace (usually due to values spanning over multiple lines).

With desc's current DESCRIPTION file:

```r
> desc::desc_get_field("Imports")
[1] "utils, R6, crayon, rprojroot"
> desc::desc_get_field("Imports", trim_ws = F)
[1] "\n    utils,\n    R6,\n    crayon,\n    rprojroot"
> desc::desc_get_field("Imports", trim_ws = T, squish_ws = F)
[1] "utils,\n    R6,\n    crayon,\n    rprojroot"
```

I also wanted to write some tests in [test-queries.R#L27](https://github.com/r-lib/desc/blob/master/tests/testthat/test-queries.R#L27) but was hit by https://github.com/r-lib/pkgload/issues/150 and have no clue how I can successfully run desc's tests...