### PR TITLE
remove `LazyData` from `!new`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # Development version
 
+* DESCRIPTION objects created with the `!new` command now omit `LazyData: true` 
+  to match new CRAN checks (#105, @malcolmbarrett)
+
 ## Breaking changes
 
 * `desc_get_field()` gains a boolean `squish_ws` parameter to normalize

--- a/R/description.R
+++ b/R/description.R
@@ -723,7 +723,6 @@ Authors@R:
 Maintainer: {{ Maintainer }}
 Description: {{ Description }}
 License: {{ License }}
-LazyData: true
 URL: {{ URL }}
 BugReports: {{ BugReports }}
 Encoding: UTF-8

--- a/tests/testthat/output/to_latex.tex
+++ b/tests/testthat/output/to_latex.tex
@@ -13,5 +13,4 @@
   \item[URL] \url{http://somewhere.io}, \url{http://somewhereel.se}
   \item[BugReports] \url{http://somewhere.io/trac}
   \item[Encoding] UTF-8
-  \item[LazyData] true
 \end{description}

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -11,7 +11,7 @@ test_that("can create new object", {
   expect_true(!is.na(desc$get("Maintainer")))
   expect_true(!is.na(desc$get("Description")))
   expect_true(!is.na(desc$get("License")))
-  expect_true(!is.na(desc$get("LazyData")))
+  expect_true(is.na(desc$get("LazyData")))
   expect_true(!is.na(desc$get("URL")))
   expect_true(!is.na(desc$get("BugReports")))
 })

--- a/tests/testthat/test-repair.R
+++ b/tests/testthat/test-repair.R
@@ -13,7 +13,7 @@ test_that("normalization", {
 
   expect_equal(sort(before_fields), sort(after_fields))
   expect_lt(match("Imports", after_fields), match("Imports", before_fields))
-  expect_gt(match("LazyData", after_fields), match("LazyData", before_fields))
+  expect_gt(match("Encoding", after_fields), match("Encoding", before_fields))
   expect_equal(after_data[["Imports"]], "\n    bar,\n    foo,\n    foobar")
 
 })
@@ -47,7 +47,7 @@ test_that("reordering", {
 
   expect_equal(sort(before_fields), sort(after_fields))
   expect_lt(match("Imports", after_fields), match("Imports", before_fields))
-  expect_gt(match("LazyData", after_fields), match("LazyData", before_fields))
+  expect_gt(match("Encoding", after_fields), match("Encoding", before_fields))
   expect_identical(before_data[after_fields], after_data)
 
 })


### PR DESCRIPTION
This PR removes `LazyData` from the `DESCRIPTION` generated by the `!new` command and updates the expectations in related tests.

See also https://github.com/r-lib/usethis/pull/1404

Closes #104 