### PR TITLE
Error when empty line present

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -19,6 +19,10 @@ read_dcf <- function(file) {
   res <- read.dcf(con, keep.white = fields)
   close(con)
 
+  if (nrow(res) > 1) {
+    stop("Empty lines found in DESCRIPTION file", call. = FALSE)
+  }
+
   con <- textConnection(lines, local = TRUE)
   res2 <- read.dcf(con, keep.white = fields, all = TRUE)
   close(con)

--- a/tests/testthat/D12
+++ b/tests/testthat/D12
@@ -1,0 +1,18 @@
+Package: desc
+Title: Manipulate DESCRIPTION Files
+Version: 1.0.0
+Author: Gábor Csárdi
+Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
+Description: Tools to read, write, create, and manipulate DESCRIPTION
+    files. It is intented for packages that create or manipulate other
+    packages.
+License: MIT + file LICENSE
+
+URL: https://github.com/r-pkgs/desc
+BugReports: https://github.com/r-pkgs/desc/issues
+Imports:
+    R6
+Suggests:
+    testthat
+VignetteBuilder: knitr
+Encoding: UTF-8

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -31,6 +31,13 @@ test_that("duplicate fields, #43", {
   )
 })
 
+test_that("empty lines error", {
+  expect_error(
+    description$new("D12"),
+    "Empty lines found in DESCRIPTION file"
+  )
+})
+
 test_that("Empty DESCRIPTION", {
   expect_error(description$new(text = ""), NA)
   expect_error(description$new(text = character()), NA)


### PR DESCRIPTION
This PR adds a check for empty lines in `DESCRIPTION` and gives a clearer error message when found

Closes #106 