### PR TITLE
better role handling in coerce_authors_at_r()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # development version
 
+* The `$coerce_authors_at_r()` method now does a much better job at setting
+  the authors' roles (#114, @dpprdan).
+
 # desc 1.4.0
 
 * DESCRIPTION objects created with the `!new` command now omit `LazyData: true` 

--- a/R/authors-at-r.R
+++ b/R/authors-at-r.R
@@ -263,7 +263,7 @@ idesc_del_author <- function(self, private, given, family, email, role,
   } else {
     au <- if (length(wh$index) == 1) "Author" else "Authors"
     desc_message(
-      au, "removed: ",
+      au, " removed: ",
       paste(wh$authors$given, wh$authors$family, collapse = ", "),
       "."
     )

--- a/R/authors-at-r.R
+++ b/R/authors-at-r.R
@@ -387,7 +387,7 @@ idesc_coerce_authors_at_r <- function(self, private) {
     # helper function to set role if role is NULL
     set_role_if_null <- function(person, role) {
       if (length(person) == 1) {
-        person$role = person$role %||% role
+        person$role <- person$role %||% role
       } else {
         person$role <- lapply(person$role, function(y) y %||% role)
       }
@@ -395,12 +395,12 @@ idesc_coerce_authors_at_r <- function(self, private) {
     }
 
     # Parse maintainer field as person and set role
-    man = self$get_maintainer()
-    man = as.person(man)
-    man = set_role_if_null(man, "cre")
+    man <- self$get_maintainer()
+    man <- as.person(man)
+    man <- set_role_if_null(man, "cre")
 
     # Parse author field as person and set role
-    auth = self$get("Author")
+    auth <- self$get("Author")
     author_file <- grepl("AUTHOR", auth, ignore.case = FALSE, fixed = TRUE)
     if (author_file) {
       desc_message(
@@ -408,11 +408,11 @@ idesc_coerce_authors_at_r <- function(self, private) {
         "Only the 'Maintainer' field will be converted to 'Authors@R'. \n",
         "You can add additional authors with $add_author."
       )
-      auth = man
-      auth$role = "aut"
+      auth <- man
+      auth$role <- "aut"
     } else {
-    auth = as.person(auth)
-    auth = set_role_if_null(auth, "aut")
+    auth <- as.person(auth)
+    auth <- set_role_if_null(auth, "aut")
     }
 
     # Determine which author is the maintainer and split auth accordingly

--- a/R/authors-at-r.R
+++ b/R/authors-at-r.R
@@ -388,8 +388,9 @@ idesc_coerce_authors_at_r <- function(self, private) {
     set_role_if_null <- function(person, role) {
       if (length(person) == 1) {
         person$role = person$role %||% role
+      } else {
+        person$role <- lapply(person$role, function(y) y %||% role)
       }
-      person$role <- lapply(person$role, function(y) y %||% role)
       person
     }
 

--- a/R/authors-at-r.R
+++ b/R/authors-at-r.R
@@ -373,17 +373,16 @@ idesc_get_maintainer <- function(self, private) {
   }
 }
 
-
 idesc_coerce_authors_at_r <- function(self, private) {
-  has_authors_at_r = self$has_fields("Authors@R")
-  has_author = self$has_fields("Author")
 
-  if (! (has_authors_at_r | has_author) ) {
+  if (self$has_fields("Authors@R")) return(invisible(NULL)) # exit early
+
+  if (!self$has_fields("Author")) {
+
     stop("No 'Authors@R' or 'Author' field!\n",
          "You can create one with $add_author")
-  }
 
-  if ( !has_authors_at_r & has_author) {
+  } else {
 
     # helper function to set role if role is NULL
     set_role_if_null <- function(person, role) {

--- a/R/non-oo-api.R
+++ b/R/non-oo-api.R
@@ -542,12 +542,21 @@ desc_add_author_gh <- generate_api("add_author_gh")
 
 desc_get_maintainer <- generate_api("get_maintainer", self = FALSE)
 
-#' Coerce Author Field to Authors@R
+#' Coerce Author and Maintainer Fields to Authors@R
 #'
-#' Convert an \sQuote{Author} to a \sQuote{Authors@R} field, which is necessary
-#' for other functions such as getting authors.
+#' Convert the \sQuote{Author} and \sQuote{Maintainer} fields to
+#' \sQuote{Authors@R}, which is necessary for other functions such as
+#' \code{desc_get_authors()}.
 #'
 #' @inheritParams desc_set
+#'
+#' @details
+#' If the \sQuote{Authors@R} field does not exist,
+#' \code{desc_coerce_authors_at_r} tries to parse the \sQuote{Author} and
+#' \sQuote{Maintainer} fields with \code{\link[utils]{as.person}} and writes
+#' them to the \sQuote{Authors@R} field.
+#' Note that \sQuote{Author} and \sQuote{Maintainer} are free-form fields, so
+#' parsing them may fail.
 #'
 #' @export
 #' @family Authors@R

--- a/man/desc_coerce_authors_at_r.Rd
+++ b/man/desc_coerce_authors_at_r.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/non-oo-api.R
 \name{desc_coerce_authors_at_r}
 \alias{desc_coerce_authors_at_r}
-\title{Coerce Author Field to Authors@R}
+\title{Coerce Author and Maintainer Fields to Authors@R}
 \usage{
 desc_coerce_authors_at_r(file = ".", normalize = FALSE)
 }
@@ -15,8 +15,17 @@ is part of) is used.}
 the result. See \code{\link{desc_normalize}}.}
 }
 \description{
-Convert an \sQuote{Author} to a \sQuote{Authors@R} field, which is necessary
-for other functions such as getting authors.
+Convert the \sQuote{Author} and \sQuote{Maintainer} fields to
+\sQuote{Authors@R}, which is necessary for other functions such as
+\code{desc_get_authors()}.
+}
+\details{
+If the \sQuote{Authors@R} field does not exist,
+\code{desc_coerce_authors_at_r} tries to parse the \sQuote{Author} and
+\sQuote{Maintainer} fields with \code{\link[utils]{as.person}} and writes
+them to the \sQuote{Authors@R} field.
+Note that \sQuote{Author} and \sQuote{Maintainer} are free-form fields so
+parsing them may fail.
 }
 \seealso{
 Other Authors@R: 

--- a/tests/testthat/D13
+++ b/tests/testthat/D13
@@ -1,0 +1,15 @@
+Package: pkgname
+Version: 0.5-1
+Date: 2015-01-01
+Title: My First Collection of Functions
+Author: Joe Developer [aut, cre],
+  Pat Developer [aut],
+  A. User [ctb]
+Maintainer: Joe Developer <Joe.Developer@some.domain.net>
+Depends: R (>= 3.1.0), nlme
+Suggests: MASS
+Description: A (one paragraph) description of what
+  the package does and why it may be useful.
+License: GPL (>= 2)
+URL: https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file
+BugReports: https://pkgname.bugtracker.url

--- a/tests/testthat/D14
+++ b/tests/testthat/D14
@@ -1,0 +1,39 @@
+Package: igraph
+Version: 1.2.6
+Title: Network Analysis and Visualization
+Author: See AUTHORS file.
+Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
+Description: Routines for simple graphs and network analysis. It can
+  handle large graphs very well and provides functions for generating random
+  and regular graphs, graph visualization, centrality methods and much more.
+Depends: methods
+Imports: graphics, grDevices, magrittr, Matrix, pkgconfig (>= 2.0.0),
+        stats, utils
+Suggests: ape, digest, graph, igraphdata, rgl, scales, stats4, tcltk,
+        testthat, withr
+License: GPL (>= 2)
+URL: https://igraph.org
+SystemRequirements: gmp (optional), libxml2 (optional), glpk (optional)
+BugReports: https://github.com/igraph/igraph/issues
+Encoding: UTF-8
+RoxygenNote: 7.1.1
+Collate: 'adjacency.R' 'auto.R' 'assortativity.R' 'attributes.R'
+        'basic.R' 'bipartite.R' 'centrality.R' 'centralization.R'
+        'cliques.R' 'cocitation.R' 'cohesive.blocks.R' 'community.R'
+        'components.R' 'console.R' 'conversion.R' 'data_frame.R'
+        'decomposition.R' 'degseq.R' 'demo.R' 'embedding.R' 'epi.R'
+        'fit.R' 'flow.R' 'foreign.R' 'games.R' 'glet.R' 'hrg.R'
+        'igraph-package.R' 'incidence.R' 'indexing.R' 'interface.R'
+        'iterators.R' 'layout.R' 'layout_drl.R' 'lazyeval.R' 'make.R'
+        'minimum.spanning.tree.R' 'motifs.R' 'nexus.R' 'operators.R'
+        'other.R' 'package.R' 'palette.R' 'par.R' 'paths.R' 'plot.R'
+        'plot.common.R' 'plot.shapes.R' 'pp.R' 'print.R' 'printr.R'
+        'random_walk.R' 'rewire.R' 'scan.R' 'scg.R' 'sgm.R'
+        'similarity.R' 'simple.R' 'sir.R' 'socnet.R' 'sparsedf.R'
+        'structural.properties.R' 'structure.info.R' 'test.R'
+        'tkplot.R' 'topology.R' 'triangles.R' 'utils.R' 'uuid.R'
+        'versions.R' 'weakref.R' 'zzz-deprecate.R'
+NeedsCompilation: yes
+Packaged: 2020-10-06 10:36:22 UTC; gaborcsardi
+Repository: CRAN
+Date/Publication: 2020-10-06 12:40:05 UTC

--- a/tests/testthat/D15
+++ b/tests/testthat/D15
@@ -1,0 +1,21 @@
+Package: SAPP
+Title: Statistical Analysis of Point Processes
+Version: 1.0.8
+Authors@R (parsed):
+    * Masami Saga <msaga@mtb.biglobe.ne.jp> [cre]
+    * The Institute of Statistical Mathematics [aut]
+Author: The Institute of Statistical Mathematics
+Maintainer: Masami Saga <msaga@mtb.biglobe.ne.jp>
+Description: Functions for statistical analysis of point
+    processes.
+License: GPL (>= 2)
+Depends:
+    R (>= 3.5.0)
+Imports:
+    graphics,
+    grDevices
+Date/Publication: 2020-06-02 23:30:09 UTC
+MailingList: Please send bug reports to ismrp@jasp.ism.ac.jp
+NeedsCompilation: yes
+Packaged: 2020-05-31 07:35:42 UTC; msaga
+Repository: CRAN

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -359,7 +359,12 @@ test_that("coerce_authors_at_r if there is no Authors@R field", {
   expect_equal(D1$get_author("cre"), D1$get_author("aut"))
 })
 
-test_that("coerce_authors_at_r error if no authors fields at all", {
+test_that("coerce_authors_at_r does nothing if there IS an Authors@R field", {
+  D2 <- description$new(teat_path("D2"))
+  expect_null(D2$coerce_authors_at_r())
+})
+
+test_that("coerce_authors_at_r errors if no authors fields at all", {
   D1 <- description$new(test_path("D1"))
   D1$del("Author")
   expect_error(D1$coerce_authors_at_r(), "No 'Authors@R' or 'Author' field!")

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -361,7 +361,7 @@ test_that("coerce_authors_at_r if there is no Authors@R field", {
 })
 
 test_that("coerce_authors_at_r does nothing if there IS an Authors@R field", {
-  D2 <- description$new(teat_path("D2"))
+  D2 <- description$new(test_path("D2"))
   expect_null(D2$coerce_authors_at_r())
 })
 

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -402,6 +402,28 @@ test_that("coerce_authors_at_r handles role tags, #114", {
   expect_equal(D13$get_author("ctb"), as.person("A. User [ctb]"))
 })
 
+test_that("coerce_authors_at_r ignores reference to AUTHOR files, #114", {
+  D14 <- description$new("D14")
+  expect_message(D14$coerce_authors_at_r(), "AUTHOR file")
+  expect_equal(
+    D14$get_authors(),
+    as.person("Gábor Csárdi <csardi.gabor@gmail.com> [aut, cre]")
+  )
+})
+
+test_that("coerce_authors_at_r handles maintainer not being author", {
+  D15 <- description$new("D15")
+  expect_silent(D15$coerce_authors_at_r())
+  expect_equal(
+    D15$get_author("cre"),
+    as.person("Masami Saga <msaga@mtb.biglobe.ne.jp> [cre]")
+  )
+  expect_equal(
+    D15$get_author("aut"),
+    as.person("The Institute of Statistical Mathematics [aut]")
+  )
+})
+
 test_that("add_author if there is no Authors@R field", {
   D1 <- description$new(test_path("D1"))
   D1$add_author("Gabor", "Csardi", "csardi.gabor@gmail.com", role = "ctb")

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -232,7 +232,8 @@ test_that("we can change the maintainer", {
 test_that("add_me works", {
   withr::local_envvar(
     FULLNAME = "Bugs Bunny",
-    EMAIL = "bugs.bunny@acme.com"
+    EMAIL = "bugs.bunny@acme.com",
+    ORCID_ID = ""
   )
 
   desc <- description$new(test_path("D2"))
@@ -436,7 +437,8 @@ test_that("add_author if there is no Authors@R field", {
 test_that("add myself if there is no Authors@R field", {
   withr::local_envvar(
     FULLNAME = "Bugs Bunny",
-    EMAIL = "bugs.bunny@acme.com"
+    EMAIL = "bugs.bunny@acme.com",
+    ORCID_ID = ""
   )
 
   D1 <- description$new(test_path("D1"))

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -186,8 +186,8 @@ test_that("we cannot add the same ORCID to more than one author", {
 test_that("we can delete an author", {
   desc <- description$new(test_path("D2"))
 
-  desc$del_author(given = "Hadley")
-  desc$del_author(family = "Danenberg")
+  expect_message(desc$del_author(given = "Hadley"), "removed:")
+  expect_message(desc$del_author(family = "Danenberg"), "removed:")
 
   ans <- c(
     person("Manuel", "Eugster", role = c("aut", "cph")),


### PR DESCRIPTION
This PR should improve the handling of roles by `coerce_authors_at_r()`. 
My main assumptions underlying the code:

- Author and Maintainer fields are not empty, as required by [WRE](https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file) (but not sure about Bioconductor for example)
- Author and Maintainer contain strings that can be parsed by `as.person()` (violated by packages with an Author file, e.g. [igraph](https://cran.r-project.org/package=igraph), so probably needs an appropriate error message)
- Only one Maintainer, as required by WRE (again dunno about Bioconductor)

closes #114