### PR TITLE
Fix location when inserting a new dependency

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -21,7 +21,7 @@ idesc_set_dep <- function(self, private, package, type, version) {
         # must be first
         idx <- which(deps$type == type)[[1]]
       } else {
-        idx <- length(idx) + 1
+        idx <- max(idx) + 1
       }
     } else {
       idx <- nrow(deps) + 1

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -72,17 +72,18 @@ test_that("set_dep preserves order", {
 
   desc$set_deps(data.frame(
     stringsAsFactors = FALSE,
-    type = "Imports",
-    package = c("covr", "testthat"),
+    type = c("Depends", "Imports", "Imports"),
+    package = c("R", "covr", "testthat"),
     version = "*"
   ))
   desc$set_dep("R6", "Imports")
 
   expect_equal(
     desc$get_deps()$package,
-    c("covr", "R6", "testthat")
+    c("R", "covr", "R6", "testthat")
   )
 })
+
 test_that("set_dep inserts at end if not ordered", {
   desc <- description$new("!new")
 


### PR DESCRIPTION
I've found the insertion can be off-by-n if the package has `Depends`.

Context: I had the general impression that desc keeps things in alphabetical order, if they start out that way. I wanted to allude to this in R Packages, so I decided to check for this behaviour and stumbled across this.