### PR TITLE
Fix $add_author() and related in non-UTf-8

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,7 @@ jobs:
           - {os: macOS-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
-          - {os: windows-2022,   r: 'devel-ucrt'}
+          - {os: windows-2022,   r: 'devel'}
 
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
@@ -45,17 +45,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@pak2
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@pak2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,15 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@pak2
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@pak2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr
           needs: coverage
 
       - name: Test coverage
-        run: covr::codecov()
+        run: covr::codecov(quiet = FALSE)
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ BugReports: https://github.com/r-lib/desc/issues
 Depends:
     R (>= 3.1.0)
 Suggests:
+    callr,
     covr,
     testthat,
     whoami,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,5 +1,7 @@
 BitBucket
 Codecov
+Csárdi
+Gábor
 IETF
 Lifecycle
 LinkingTo

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,7 +1,7 @@
 
 temp_desc <- function(file = "D2") {
   tmp <- tempfile()
-  file.copy(file, tmp)
+  file.copy(test_path(file), tmp)
   tmp
 }
 

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -25,14 +25,14 @@ test_that("we can set the authors", {
 })
 
 test_that("we can add an author", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
-  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] (Really?)"
+    "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [ctb] (Really?)"
   )
 })
 
@@ -46,14 +46,14 @@ test_that("we can add an author with ORCID via comment", {
 
   desc <- description$new(cmd = "!new")
 
-  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb",
                   comment = c(ORCID = "0000-0001-7098-9676", what="he did it"))
 
   expect_identical(
     format(desc$get_authors()[2]),
     paste0(
-      "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] ",
+      "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [ctb] ",
       "(<https://orcid.org/0000-0001-7098-9676>, he did it)"
     )
   )
@@ -69,7 +69,7 @@ test_that("we can add an author with ORCID", {
 
   desc <- description$new(cmd = "!new")
 
-  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb",
                   comment = c(what="he did it"),
                   orcid = "0000-0001-7098-9676")
@@ -77,7 +77,7 @@ test_that("we can add an author with ORCID", {
   expect_identical(
     format(desc$get_authors()[2]),
     paste0(
-      "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] ",
+      "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [ctb] ",
       "(he did it, <https://orcid.org/0000-0001-7098-9676>)"
     )
   )
@@ -87,7 +87,7 @@ test_that("we cannot add an author with malformatted comment", {
 
   desc <- description$new(cmd = "!new")
 
-  expect_error(desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  expect_error(desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb",
                   comment = c(ORCID = "orcid_number", what=NA)),
                "is_named_character_or_null")
@@ -120,13 +120,13 @@ test_that("we can search for authors", {
 test_that("we can add a role to an author", {
   desc <- description$new("D2")
 
-  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
-  desc$add_role(given = "Gábor", role = "cph")
+  desc$add_role(given = "G\u00e1bor", role = "cph")
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [ctb, cph] (Really?)"
+    "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [ctb, cph] (Really?)"
   )
 })
 
@@ -139,14 +139,14 @@ test_that("we can add an ORCID to an author", {
 
   desc <- description$new("D2")
 
-  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
-  desc$add_orcid(given = "Gábor", orcid = "0000-0001-7098-9676")
+  desc$add_orcid(given = "G\u00e1bor", orcid = "0000-0001-7098-9676")
 
   expect_identical(
     format(desc$get_authors()[5]),
     paste0(
-      "Gábor Csárdi <csardi.gabor@gmail.com> [ctb] ",
+      "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [ctb] ",
       "(Really?, <https://orcid.org/0000-0001-7098-9676>)"
     )
   )
@@ -200,14 +200,14 @@ test_that("we can delete an author", {
 test_that("we can delete a role", {
   desc <- description$new("D2")
 
-  desc$add_author("Gábor", "Csárdi", email = "csardi.gabor@gmail.com",
+  desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
-  desc$add_role(given = "Gábor", role = "cph")
-  desc$del_role(family = "Csárdi", role = "ctb")
+  desc$add_role(given = "G\u00e1bor", role = "cph")
+  desc$del_role(family = "Cs\u00e1rdi", role = "ctb")
 
   expect_identical(
     format(desc$get_authors()[5]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [cph] (Really?)"
+    "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [cph] (Really?)"
   )
 })
 
@@ -296,7 +296,7 @@ test_that("message if not author to delete does not exist", {
 
   desc <- description$new("D2")
   expect_message(
-    desc$del_author(given = "Gábor"),
+    desc$del_author(given = "G\u00e1bor"),
     "Could not find author to remove"
   )
 })
@@ -353,7 +353,7 @@ test_that("coerce_authors_at_r if there is no Authors@R field", {
   expect_silent(D1$get_authors())
   expect_identical(
     format(D1$get_authors()[1]),
-    "Gábor Csárdi <csardi.gabor@gmail.com> [cre]"
+    "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com> [cre]"
   )
 })
 

--- a/tests/testthat/test-authors.R
+++ b/tests/testthat/test-authors.R
@@ -1,6 +1,6 @@
 
 test_that("we can get the authors", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   ans <- c(
     person("Hadley", "Wickham", email = "h.wickham@gmail.com",
@@ -16,8 +16,8 @@ test_that("we can get the authors", {
 
 test_that("we can set the authors", {
 
-  desc1 <- description$new("D1")
-  desc2 <- description$new("D2")
+  desc1 <- description$new(test_path("D1"))
+  desc2 <- description$new(test_path("D2"))
 
   desc1$set_authors(desc2$get_authors())
 
@@ -25,7 +25,7 @@ test_that("we can set the authors", {
 })
 
 test_that("we can add an author", {
-  desc <- description$new(test_path("D2"))
+  desc <- description$new(test_path(test_path("D2")))
 
   desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
@@ -96,7 +96,7 @@ test_that("we cannot add an author with malformatted comment", {
 })
 
 test_that("we can search for authors", {
-  desc <- description$new("D9")
+  desc <- description$new(test_path("D9"))
   authors <- desc$get_authors()
 
   expect_equal(
@@ -118,7 +118,7 @@ test_that("we can search for authors", {
 })
 
 test_that("we can add a role to an author", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
@@ -137,7 +137,7 @@ test_that("we can add an ORCID to an author", {
 
   skip_if_not(R_version >= "3.5.0")
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
@@ -159,7 +159,7 @@ test_that("we can replace the ORCID of an author", {
 
   skip_if_not(R_version >= "3.5.0")
 
-  desc <- description$new("D9")
+  desc <- description$new(test_path("D9"))
 
   desc$add_orcid(given = "Hadley", orcid = "0000-0003-4757-117X")
 
@@ -174,7 +174,7 @@ test_that("we can replace the ORCID of an author", {
 
 test_that("we cannot add the same ORCID to more than one author", {
 
-  desc <- description$new("D10")
+  desc <- description$new(test_path("D10"))
 
   expect_error(desc$add_orcid(given = "Peter",
                               orcid = "orcidid"),
@@ -184,7 +184,7 @@ test_that("we cannot add the same ORCID to more than one author", {
 
 
 test_that("we can delete an author", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   desc$del_author(given = "Hadley")
   desc$del_author(family = "Danenberg")
@@ -198,7 +198,7 @@ test_that("we can delete an author", {
 })
 
 test_that("we can delete a role", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   desc$add_author("G\u00e1bor", "Cs\u00e1rdi", email = "csardi.gabor@gmail.com",
                   role = "ctb", comment = "Really?")
@@ -212,7 +212,7 @@ test_that("we can delete a role", {
 })
 
 test_that("we can change the maintainer", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   desc$change_maintainer(given = "Peter")
 
@@ -235,7 +235,7 @@ test_that("add_me works", {
     EMAIL = "bugs.bunny@acme.com"
   )
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   desc$add_me(comment = "Yikes!")
 
   expect_identical(
@@ -257,7 +257,7 @@ test_that("add_me can use ORCID_ID", {
     ORCID_ID = "0000-0002-0775-162X"
   )
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   desc$add_me()
 
   expect_identical(
@@ -274,7 +274,7 @@ test_that("add_author_gh works", {
     desc.gh_user = list(name = "Jeroen Ooms", email = "notanemail")
   )
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   desc$add_author_gh(username = "jeroen")
 
   expect_identical(
@@ -285,7 +285,7 @@ test_that("add_author_gh works", {
 
 test_that("error if not Authors@R field", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   expect_error(
     desc$get_authors(),
     "No 'Authors@R' field"
@@ -294,7 +294,7 @@ test_that("error if not Authors@R field", {
 
 test_that("message if not author to delete does not exist", {
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   expect_message(
     desc$del_author(given = "G\u00e1bor"),
     "Could not find author to remove"
@@ -303,7 +303,7 @@ test_that("message if not author to delete does not exist", {
 
 test_that("get_author is OK", {
 
-  D2 <- description$new("D2")
+  D2 <- description$new(test_path("D2"))
 
   expect_equal(
     D2$get_author(role = "cre"),
@@ -321,19 +321,19 @@ test_that("get_author is OK", {
     D2$get_authors()[1:3]
   )
 
-  D1 <- description$new("D1")
+  D1 <- description$new(test_path("D1"))
   expect_null(D1$get_author(role = "cre"))
 })
 
 test_that("get_maintainer is OK, too", {
 
-  D1 <- description$new("D1")
+  D1 <- description$new(test_path("D1"))
   expect_equal(
     D1$get_maintainer(),
     "G\u00e1bor Cs\u00e1rdi <csardi.gabor@gmail.com>"
   )
 
-  D2 <- description$new("D2")
+  D2 <- description$new(test_path("D2"))
   expect_equal(
     D2$get_maintainer(),
     "Hadley Wickham <h.wickham@gmail.com>"
@@ -347,7 +347,7 @@ test_that("get_maintainer is OK, too", {
 })
 
 test_that("coerce_authors_at_r if there is no Authors@R field", {
-  D1 <- description$new("D1")
+  D1 <- description$new(test_path("D1"))
   expect_error(D1$get_authors())
   D1$coerce_authors_at_r()
   expect_silent(D1$get_authors())
@@ -359,18 +359,18 @@ test_that("coerce_authors_at_r if there is no Authors@R field", {
 
 
 test_that("coerce_authors_at_r error if no authors fields at all", {
-  D1 <- description$new("D1")
+  D1 <- description$new(test_path("D1"))
   D1$del("Author")
   expect_error(D1$coerce_authors_at_r())
 })
 
 test_that("coerce_authors_at_r with multiple authors in Author: field", {
-  D6 <- description$new("D6")
+  D6 <- description$new(test_path("D6"))
   expect_silent(D6$coerce_authors_at_r())
 })
 
 test_that("add_author if there is no Authors@R field", {
-  D1 <- description$new("D1")
+  D1 <- description$new(test_path("D1"))
   D1$add_author("Gabor", "Csardi", "csardi.gabor@gmail.com", role = "ctb")
   expect_identical(
     format(D1$get_authors()[1]),
@@ -384,7 +384,7 @@ test_that("add myself if there is no Authors@R field", {
     EMAIL = "bugs.bunny@acme.com"
   )
 
-  D1 <- description$new("D1")
+  D1 <- description$new(test_path("D1"))
   D1$add_me(comment = "Yikes!")
 
   expect_identical(

--- a/tests/testthat/test-built.R
+++ b/tests/testthat/test-built.R
@@ -1,6 +1,6 @@
 
 test_that("get built", {
-  desc <- description$new("D4")
+  desc <- description$new(test_path("D4"))
   expect_identical(
     desc$get_built(),
     list(R = R_system_version("3.4.1"),

--- a/tests/testthat/test-checks.R
+++ b/tests/testthat/test-checks.R
@@ -1,7 +1,7 @@
 
 test_that("checking other fields is always ok", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$set("Note", "Blah-blah")
 
   expect_equal(desc$get("Note"), c(Note = "Blah-blah"))
@@ -10,7 +10,7 @@ test_that("checking other fields is always ok", {
 
 test_that("we catch syntax errors", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_warning(
     desc$set("Package", "444!!! not a valid package name"),

--- a/tests/testthat/test-collate.R
+++ b/tests/testthat/test-collate.R
@@ -1,6 +1,6 @@
 
 test_that("set_collate and get_collate work", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   files <- c("foo.R", "bar.R", "foobar.R")
   desc$set_collate(files)
@@ -26,7 +26,7 @@ test_that("set_collate and get_collate work", {
 })
 
 test_that("del_collate works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   files <- c("foo.R", "bar.R", "foobar.R")
   files2 <- c(files, "foo-win.R")
@@ -51,7 +51,7 @@ test_that("del_collate works", {
 })
 
 test_that("add_to_collate works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   desc$add_to_collate("bar.R")
   expect_equal(desc$get_collate(), "bar.R")
@@ -71,7 +71,7 @@ test_that("add_to_collate works", {
 })
 
 test_that("del_from_collate works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   files <- c("foo.R", "bar.R", "foobar.R")
   files2 <- c(files, "foo-win.R")
@@ -101,7 +101,7 @@ test_that("del_from_collate works", {
 
 test_that("add to all collate fields", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$set_collate(c("f1.R", "f2.R"), which = "main")
   desc$set_collate(c("f3.R", "f4.R"), which = "win")
   desc$add_to_collate("f5.R", which = "all")
@@ -118,6 +118,6 @@ test_that("add to all collate fields", {
 
 test_that("deleting from non-existing collate does nothing", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   expect_silent(desc$del_from_collate('foo.R'))
 })

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -15,7 +15,7 @@ test_that("can create new object", {
 })
 
 test_that("can read object from file", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_true(!is.na(desc$get("Package")))
   expect_true(!is.na(desc$get("Title")))
@@ -30,7 +30,7 @@ test_that("can read object from file", {
 })
 
 test_that("can read object from character vector", {
-  lines <- readLines("D1")
+  lines <- readLines(test_path("D1"))
   desc <- description$new(text = lines)
 
   expect_true(!is.na(desc$get("Package")))

--- a/tests/testthat/test-deps.R
+++ b/tests/testthat/test-deps.R
@@ -1,6 +1,6 @@
 
 test_that("get_deps", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   res <- data.frame(
     stringsAsFactors = FALSE,
@@ -102,7 +102,7 @@ test_that("set_dep inserts at end if not ordered", {
 })
 
 test_that("del_dep", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   desc$set_dep("igraph")
   desc$set_dep("igraph", type = "Depends", version = ">= 1.0.0")
@@ -117,7 +117,7 @@ test_that("del_dep", {
 
   expect_equal(desc$get_deps(), res)
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   desc$set_dep("igraph")
   desc$set_dep("igraph", type = "Depends", version = ">= 1.0.0")
@@ -136,7 +136,7 @@ test_that("del_dep", {
 
 test_that("deleting all dependencies", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$del_deps()
   expect_equal(desc$get("Imports"), c(Imports = NA_character_))
   expect_equal(desc$get("Suggests"), c(Suggests = NA_character_))
@@ -145,7 +145,7 @@ test_that("deleting all dependencies", {
 
 test_that("deleting a non-dependency is OK", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   before <- desc$get("Imports")
   desc$del_dep("foobar", "Imports")
   after <- desc$get("Imports")
@@ -154,7 +154,7 @@ test_that("deleting a non-dependency is OK", {
 
 test_that("has_dep", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   expect_true(desc$has_dep("R6"))
   expect_true(desc$has_dep("testthat"))
 
@@ -170,7 +170,7 @@ test_that("has_dep", {
 })
 
 test_that("has_dep works when package listed twice", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   expect_true(desc$has_dep("Rcpp"))
   expect_true(desc$has_dep("Rcpp", "Imports"))
   expect_true(desc$has_dep("Rcpp", "LinkingTo"))
@@ -186,7 +186,7 @@ test_that("issue #34 is fine (empty dep fields)", {
     version = character()
   )
 
-  desc <- description$new("D4")
+  desc <- description$new(test_path("D4"))
   expect_silent(deps <- desc$get_deps())
   expect_equal(deps, empty_deps)
 
@@ -208,7 +208,7 @@ test_that("no dependencies at all", {
     version = character()
   )
 
-  desc <- description$new("D6")
+  desc <- description$new(test_path("D6"))
   expect_silent(deps <- desc$get_deps())
   expect_equal(deps, empty_deps)
 

--- a/tests/testthat/test-desc.R
+++ b/tests/testthat/test-desc.R
@@ -1,7 +1,7 @@
 
 test_that("desc wrapper works", {
   expect_equal(
-    desc("D2"),
-    description$new("D2")
+    desc(test_path("D2")),
+    description$new(test_path("D2"))
   )
 })

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -15,7 +15,7 @@ test_that("Encoding field is observed", {
     )
   )
 
-  expect_silent(desc$set(Author = "Gábor Csárdi"))
+  expect_silent(desc$set(Author = "G\u00e1bor Cs\u00e1rdi"))
 })
 
 test_that("Unset Encoding results warning", {
@@ -26,7 +26,7 @@ test_that("Unset Encoding results warning", {
         "Package: foo\n",
         "Title: Foo Package\n",
         "Author: Package Author\n",
-        "Maintainer: Gábor Csárdi <author@here.net>\n",
+        "Maintainer: G\u00e1bor Cs\u00e1rdi <author@here.net>\n",
         "Description: The great foo package.\n",
         "License: GPL\n"
       )
@@ -34,7 +34,7 @@ test_that("Unset Encoding results warning", {
     "Encoding"
   )
 
-  expect_warning(desc$set(Author = "Gábor Csárdi"), "Encoding")
+  expect_warning(desc$set(Author = "G\u00e1bor Cs\u00e1rdi"), "Encoding")
 
 })
 

--- a/tests/testthat/test-idempotent.R
+++ b/tests/testthat/test-idempotent.R
@@ -1,14 +1,14 @@
 
 test_that("dependencies are not reformatted if new value is the same", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$set("Imports", "R6")
   before <- desc$get("Imports")
   desc$set_dep("R6")
   after <- desc$get("Imports")
   expect_equal(before, after)
   
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$set("Imports", "R6")
   before <- desc$get("Imports")
   desc$set_deps(data.frame(package = "R6", type = "Imports", version = "*"))
@@ -19,7 +19,7 @@ test_that("dependencies are not reformatted if new value is the same", {
 
 test_that("collate fields are not reformatted if new value is the same", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$set("Collate", "'foo.R' 'bar.R' foobar.R")
   before <- desc$get("Collate")
   desc$set_collate(desc$get_collate())

--- a/tests/testthat/test-non-oo.R
+++ b/tests/testthat/test-non-oo.R
@@ -162,7 +162,7 @@ test_that("desc_normalize", {
 test_that("desc_print", {
   d <- temp_desc()
   on.exit(unlink(d))
-  capt <- capture.output(description$new("D2")$print())
+  capt <- capture.output(description$new(test_path("D2"))$print())
   expect_output(
     desc_print(file = d),
     paste(capt, collapse = "\n"),
@@ -176,7 +176,7 @@ test_that("desc_reformat_fields", {
   desc_reformat_fields(file = d)
   expect_equal(
     desc_get(file = d, "Description"),
-    description$new("D2")$reformat_fields()$get("Description")
+    description$new(test_path("D2"))$reformat_fields()$get("Description")
   )
 })
 
@@ -193,12 +193,12 @@ test_that("desc_reorder_fields", {
 })
 
 test_that("desc_set_authors", {
-  d <- temp_desc("D1")
+  d <- temp_desc(test_path("D1"))
   on.exit(unlink(d))
-  desc_set_authors(file = d, desc_get_authors(file = "D2"))
+  desc_set_authors(file = d, desc_get_authors(file = test_path("D2")))
   expect_equal(
     desc_get_authors(file = d),
-    desc_get_authors("D2")
+    desc_get_authors(test_path("D2"))
   )
 })
 
@@ -224,23 +224,23 @@ test_that("desc_set_dep", {
 test_that("desc_set_deps", {
   d <- temp_desc()
   on.exit(unlink(d))
-  desc_set_deps(file = d, desc_get_deps(file = "D1"))
+  desc_set_deps(file = d, desc_get_deps(file = test_path("D1")))
   expect_equal(
     desc_get_deps(file = d),
-    desc_get_deps(file = "D1")
+    desc_get_deps(file = test_path("D1"))
   )
 })
 
 test_that("desc_to_latex", {
   expect_equal(
-    desc_to_latex(file = "D2"),
-    description$new("D2")$to_latex()
+    desc_to_latex(file = test_path("D2")),
+    description$new(test_path("D2"))$to_latex()
   )
 })
 
 test_that("desc_validate", {
   expect_warning(
-    desc_validate(file = "D1"),
+    desc_validate(file = test_path("D1")),
     "not implemented"
   )
 })

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -1,6 +1,6 @@
 
 test_that("get works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_equal(desc$get("Package"), c(Package = "desc"))
   expect_equal(desc$get("Version"), c(Version = "1.0.0"))
@@ -9,13 +9,13 @@ test_that("get works", {
 })
 
 test_that("get nothing", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   empty <- structure(character(), names = character())
   expect_identical(desc$get(character()), empty)
 })
 
 test_that("get_field works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_identical(desc$get_field("Package"), "desc")
   expect_identical(desc$get_field("Version"), "1.0.0")
@@ -34,7 +34,7 @@ test_that("get_field works", {
 })
 
 test_that("get_or_fail works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_equal(desc$get_or_fail("Package"), c(Package = "desc"))
   expect_equal(desc$get_or_fail("Version"), c(Version = "1.0.0"))
@@ -61,7 +61,7 @@ test_that("get_or_fail works", {
 })
 
 test_that("set works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   expect_equal(desc$get("Package"), c(Package = "desc"))
 
   desc$set(Package = "foobar")
@@ -80,12 +80,12 @@ test_that("set works", {
 })
 
 test_that("get with non-exixting fields", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   expect_equal(desc$get("foobar"), c(foobar = NA_character_))
 })
 
 test_that("del works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$del("Package")
   expect_equal(desc$get("Package"), c(Package = NA_character_))
   expect_false(is.na(desc$get("Title")))
@@ -93,7 +93,7 @@ test_that("del works", {
 
 test_that("set errors on invalid input", {
 
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   expect_error(
     desc$set("foobar"),
     "needs two unnamed args"
@@ -101,7 +101,7 @@ test_that("set errors on invalid input", {
 })
 
 test_that("get_list, set_list", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   desc$set(foo = "  this, is   a, \n   list")
   expect_equal(
     desc$get_list("foo"),

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -1,6 +1,6 @@
 
 test_that("DCF reader works", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_equal(desc$get("Package"), c(Package = "desc"))
   expect_equal(desc$get("Version"), c(Version = "1.0.0"))
@@ -9,7 +9,7 @@ test_that("DCF reader works", {
 })
 
 test_that("DCF reader keeps whitespace", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   expect_equal(desc$get("Suggests"), c(Suggests = "\n    testthat"))
   expect_equal(desc$get("Description"), c(
@@ -24,14 +24,14 @@ test_that("DCF reader keeps whitespace", {
 
 test_that("duplicate fields, #43", {
   expect_error(
-    description$new("D5"),
+    description$new(test_path("D5")),
     "Duplicate DESCRIPTION fields.*Remotes"
   )
 })
 
 test_that("empty lines error", {
   expect_error(
-    description$new("D12"),
+    description$new(test_path("D12")),
     "Empty lines found in DESCRIPTION file"
   )
 })

--- a/tests/testthat/test-remotes.R
+++ b/tests/testthat/test-remotes.R
@@ -1,6 +1,6 @@
 
 test_that("get, set, etc. remotes", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   expect_identical(
     desc$get_remotes(),
     c("foo/digest",

--- a/tests/testthat/test-str.R
+++ b/tests/testthat/test-str.R
@@ -26,7 +26,7 @@ test_that("str formats some fields specially", {
 
 test_that("str formats authors properly", {
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   expect_snapshot(
     cat(crayon::strip_style(desc$str(by_field = TRUE)[["Authors@R"]]))
@@ -35,7 +35,7 @@ test_that("str formats authors properly", {
 
 test_that("authors are printed to the screen properly", {
 
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
 
   expect_output(
     print(desc),
@@ -50,7 +50,7 @@ test_that("authors are printed to the screen properly", {
 })
 
 test_that("continuation lines", {
-  desc <- description$new("D7")
+  desc <- description$new(test_path("D7"))
   t1 <- desc$str(normalize = TRUE)
   t2 <- desc$str(normalize = FALSE)
   expect_false(grepl("\n[ \t]*\n", t1))

--- a/tests/testthat/test-to_latex.R
+++ b/tests/testthat/test-to_latex.R
@@ -2,7 +2,7 @@
 test_that("Test expected LaTeX output", {
   desc <- description$new("!new")
 
-  desc$set_authors(person("Kirill", "Müller", email = "aaa@bbb.xx", role = "cre"))
+  desc$set_authors(person("Kirill", "M\u{00fc}ller", email = "aaa@bbb.xx", role = "cre"))
   desc$set(Package = "Test.Package",
            Title = "Must be in Title Case",
            Description = "Words not in the dictionary must be 'quoted'. \"Double quotes\" can also be used, as well as \\_{}[]^$#%. Must end with a full stop.",
@@ -10,10 +10,10 @@ test_that("Test expected LaTeX output", {
            URL = "http://somewhere.io, http://somewhereel.se",
            BugReports = "http://somewhere.io/trac")
 
-  new <- capture_output(print(desc$to_latex()))
+  new <- capture.output(print(desc$to_latex()))
   old <- readLines(test_path("output/to_latex.tex"), encoding = "UTF-8")
 
-  new1 <- strsplit(new, "\n")[[1]]
+  new1 <- enc2native(new)
   old1 <- enc2native(old)
 
   expect_equal(new1, old1)

--- a/tests/testthat/test-trailing-ws.R
+++ b/tests/testthat/test-trailing-ws.R
@@ -1,14 +1,14 @@
 
 test_that("No WS is kept if field is not modified", {
-  d <- description$new("D3")
+  d <- description$new(test_path("D3"))
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   d$write(tmp)
-  expect_equal(readLines("D3"), readLines(tmp))
+  expect_equal(readLines(test_path("D3")), readLines(tmp))
 })
 
 test_that("WS is present in newly created fields", {
-  d <- description$new("D3")
+  d <- description$new(test_path("D3"))
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   d$set("Foobar" = "\n    TRAZ")
@@ -27,7 +27,7 @@ test_that("WS is present in newly created files", {
 })
 
 test_that("WS is added if field is changed", {
-  d <- description$new("D3")
+  d <- description$new(test_path("D3"))
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   d$set(Author = "Gabor Csardi <foo@bar.com>")
@@ -37,7 +37,7 @@ test_that("WS is added if field is changed", {
 })
 
 test_that("No WS is added if an other field is changed", {
-  d <- description$new("D3")
+  d <- description$new(test_path("D3"))
   tmp <- tempfile()
   on.exit(unlink(tmp), add = TRUE)
   d$add_author("Gabor", "Csardi", "foo@bar.com")

--- a/tests/testthat/test-urls.R
+++ b/tests/testthat/test-urls.R
@@ -1,6 +1,6 @@
 
 test_that("get, set, etc. urls", {
-  desc <- description$new("D2")
+  desc <- description$new(test_path("D2"))
   expect_identical(
     desc$get_urls(), "https://github.com/klutometis/roxygen"
   )
@@ -29,7 +29,7 @@ test_that("get, set, etc. urls", {
 })
 
 test_that("leading newlines and embedded descriptors are ignored", {
-  desc <- description$new("D8")
+  desc <- description$new(test_path("D8"))
   expect_identical(
     desc$get_urls(),
     c("https://github.com/ropensci/hunspell#readme",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -82,3 +82,19 @@ test_that("parse_full_name works", {
 
 
 })
+
+test_that("deparse", {
+  x <- "G\u00e1bor \U1F680"
+  expect_equal(utf8ToInt(x), c(71L, 225L, 98L, 111L, 114L, 32L, 128640L))
+  dx <- fixed_deparse1(x)
+  expect_equal(dx, paste0("\"", x, "\""))
+  expect_equal(Encoding(dx), "UTF-8")
+
+  # Test in non-UTF-8 locale as well
+  dx2 <- callr::r(function(x) {
+    Sys.setlocale("LC_ALL", "C")
+    asNamespace("desc")$fixed_deparse1(x)
+  }, list(x = x))
+  expect_equal(dx2, paste0("\"", x, "\""))
+  expect_equal(Encoding(dx2), "UTF-8")
+})

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -1,6 +1,6 @@
 
 test_that("get_version", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
   v <- desc$get_version()
   expect_true(inherits(v, "package_version"))
   expect_equal(as.character(v), "1.0.0")
@@ -10,7 +10,7 @@ test_that("get_version", {
 })
 
 test_that("set_version", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   desc$set_version("2.1.3")$set_version("2.1.4")
   expect_equal(desc$get_version(), package_version("2.1.4"))
@@ -23,7 +23,7 @@ test_that("set_version", {
 })
 
 test_that("bump_version", {
-  desc <- description$new("D1")
+  desc <- description$new(test_path("D1"))
 
   cases <- list(
     c("1.2.3", "major", "2.0.0"),
@@ -66,7 +66,7 @@ test_that("bump_version", {
 })
 
 test_that("message class", {
-  desc <- description$new(test_path("D1"))
+  desc <- description$new(test_path(test_path("D1")))
   expect_message(
     desc$bump_version("patch"),
     class = "descMessage"


### PR DESCRIPTION
deparse() cannot restore UTF-8 strings in
non-UTF-8 locales, so we need to do this
manually.