### PR TITLE
Fix RStudio's listing in Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
     person("Jim", "Hester", , "james.f.hester@gmail.com", role = "aut"),
     person("Maëlle", "Salmon", role = "ctb",
            comment = c(ORCID = "0000-0002-2815-0399")),
-    person("RStudio", role = "cph", "fnd")
+    person("RStudio", role = c("cph", "fnd"))
   )
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Tools to read, write, create, and manipulate DESCRIPTION

--- a/man/desc-package.Rd
+++ b/man/desc-package.Rd
@@ -29,6 +29,7 @@ Authors:
 Other contributors:
 \itemize{
   \item Maëlle Salmon (\href{https://orcid.org/0000-0002-2815-0399}{ORCID}) [contributor]
+  \item RStudio [copyright holder, funder]
 }
 
 }


### PR DESCRIPTION
Stumbled across this while doing some analysis needed to make usethis better recognizing RStudio-associated packages.

