### PR TITLE
Ensure `get_list()` returns unaltered default value when key is not found

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -895,7 +895,12 @@ idesc_get_or_fail <- function(self, private, keys) {
 
 idesc_get_list <- function(self, private, key, default, sep, trim_ws, squish_ws) {
   stopifnot(is_string(key), is_flag(trim_ws), is_flag(squish_ws))
-  val <- private$data[[key]]$value %||% default
+
+  val <- private$data[[key]]$value
+  if (is.null(val)) {
+    return(default)
+  }
+
   val <- strsplit(val, sep, fixed = TRUE)[[1]]
   if (trim_ws) val <- str_trim(val)
   if (squish_ws) val <- str_squish(val)

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -119,6 +119,17 @@ test_that("get_list, set_list", {
     desc$get_list("foo", trim_ws = FALSE, squish_ws = FALSE),
     c("  this", " is   a", " \n   list")
   )
+  expect_equal(
+    desc$get_list("notafield", default = ""),
+    ""
+  )
+  expect_equal(
+    desc$get_list("notafield", default = c("foo", "bar")),
+    c("foo", "bar")
+  )
+  expect_error(
+    desc$get_list("notafield")
+  )
 
   desc$set_list("key", c("this", "that"))
   expect_equal(desc$get_list("key"), c("this", "that"))

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -128,7 +128,8 @@ test_that("get_list, set_list", {
     c("foo", "bar")
   )
   expect_error(
-    desc$get_list("notafield")
+    desc$get_list("notafield"),
+    "Field 'notafield' not found"
   )
 
   desc$set_list("key", c("this", "that"))


### PR DESCRIPTION
Closes #138 