### PR TITLE
Add ability to create desc object from named vector (Fixes #132)

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -17,7 +17,7 @@
 #'   note that in this case `$write()` cannot write the file back in
 #'   the package archive.
 #' @param text A character scalar containing the full DESCRIPTION, or
-#'   A named character vector with names as DESCRIPTION field names
+#'   a named character vector with names as DESCRIPTION field names
 #'   and values as field values. Unnamed character vectors are
 #'   collapsed into a character scalar, with newline as the separator.
 #' @param package If not NULL, then the name of an installed package

--- a/R/description.R
+++ b/R/description.R
@@ -16,9 +16,10 @@
 #'   binary), in which case the `DESCRIPTION` file is extracted from it, but
 #'   note that in this case `$write()` cannot write the file back in
 #'   the package archive.
-#' @param text A character scalar containing the full DESCRIPTION.
-#'   Character vectors are collapsed into a character scalar, with
-#'   newline as the separator.
+#' @param text A character scalar containing the full DESCRIPTION, or
+#'   A named character vector with names as DESCRIPTION field names
+#'   and values as field values. Unnamed character vectors are
+#'   collapsed into a character scalar, with newline as the separator.
 #' @param package If not NULL, then the name of an installed package
 #'     and the DESCRIPTION file of this package will be loaded.
 #'
@@ -69,9 +70,10 @@ desc <- function(cmd = NULL, file = NULL, text = NULL, package = NULL) {
 #'   also be an R package (source, or binary), in which case the
 #'   `DESCRIPTION` file is extracted from it, but note that in this case
 #'   `$write()` cannot write the file back in the package archive.
-#' * `text`: a character scalar containing the full DESCRIPTION.
-#'   Character vectors are collapsed into a character scalar, with
-#'   newline as the separator.
+#' * `text`: a character scalar containing the full DESCRIPTION, or
+#'   a named character vector with names as DESCRIPTION field names
+#'   and values as field values. Unnamed character vectors are
+#'   collapsed into a character scalar, with newline as the separator.
 #' * `package`: if not NULL, then the name of an installed package
 #'   and the DESCRIPTION file of this package will be loaded.
 #'
@@ -877,6 +879,19 @@ idesc_create_file <- function(self, private, file) {
 
 idesc_create_text <- function(self, private, text) {
   stopifnot(is.character(text))
+
+  if (!is.null(names(text))) {
+    if (!all(nzchar(names(text)))) {
+      stop("text arg cannot have a mix of named and unnamed elements")
+    }
+
+    # If text is a named vector, use names for field names and values
+    # for field values
+    text <- paste0(
+      names(text), ": ", text, collapse = "\n"
+    )
+  }
+
   con <- textConnection(text, local = TRUE, encoding = "bytes")
   on.exit(close(con), add = TRUE)
   dcf <- read_dcf(con)

--- a/man/desc.Rd
+++ b/man/desc.Rd
@@ -21,7 +21,7 @@ note that in this case \verb{$write()} cannot write the file back in
 the package archive.}
 
 \item{text}{A character scalar containing the full DESCRIPTION, or
-A named character vector with names as DESCRIPTION field names
+a named character vector with names as DESCRIPTION field names
 and values as field values. Unnamed character vectors are
 collapsed into a character scalar, with newline as the separator.}
 

--- a/man/desc.Rd
+++ b/man/desc.Rd
@@ -20,9 +20,10 @@ binary), in which case the \code{DESCRIPTION} file is extracted from it, but
 note that in this case \verb{$write()} cannot write the file back in
 the package archive.}
 
-\item{text}{A character scalar containing the full DESCRIPTION.
-Character vectors are collapsed into a character scalar, with
-newline as the separator.}
+\item{text}{A character scalar containing the full DESCRIPTION, or
+A named character vector with names as DESCRIPTION field names
+and values as field values. Unnamed character vectors are
+collapsed into a character scalar, with newline as the separator.}
 
 \item{package}{If not NULL, then the name of an installed package
 and the DESCRIPTION file of this package will be loaded.}

--- a/man/description.Rd
+++ b/man/description.Rd
@@ -46,9 +46,10 @@ then the search is started from the working directory. The file can
 also be an R package (source, or binary), in which case the
 \code{DESCRIPTION} file is extracted from it, but note that in this case
 \verb{$write()} cannot write the file back in the package archive.
-\item \code{text}: a character scalar containing the full DESCRIPTION.
-Character vectors are collapsed into a character scalar, with
-newline as the separator.
+\item \code{text}: a character scalar containing the full DESCRIPTION, or
+a named character vector with names as DESCRIPTION field names
+and values as field values. Unnamed character vectors are
+collapsed into a character scalar, with newline as the separator.
 \item \code{package}: if not NULL, then the name of an installed package
 and the DESCRIPTION file of this package will be loaded.
 }

--- a/tests/testthat/_snaps/create.md
+++ b/tests/testthat/_snaps/create.md
@@ -1,3 +1,11 @@
+# partially named vectors passed to 'text' fail
+
+    Code
+      description$new(text = c(foo = "bar", "baz"))
+    Condition
+      Error in `idesc_create_text()`:
+      ! text arg cannot have a mix of named and unnamed elements
+
 # From installed package
 
     Code

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -42,6 +42,24 @@ test_that("can read object from character vector", {
   expect_true(!is.na(desc$get("BugReports")))
 })
 
+test_that("can read object from named character vector", {
+  lines <- readLines(test_path("D1"))
+  desc <- description$new(text = lines)
+
+  named_fields <- desc$get(desc$fields())
+
+  new_desc <- description$new(text = named_fields)
+
+  expect_equal(desc$get("Package"), new_desc$get("Package"))
+  expect_equal(desc$get("Title"), new_desc$get("Title"))
+  expect_equal(desc$get("Author"), new_desc$get("Author"))
+  expect_equal(desc$get("Maintainer"), new_desc$get("Maintainer"))
+  expect_equal(desc$get("Description"), new_desc$get("Description"))
+  expect_equal(desc$get("License"), new_desc$get("License"))
+  expect_equal(desc$get("URL"), new_desc$get("URL"))
+  expect_equal(desc$get("BugReports"), new_desc$get("BugReports"))
+})
+
 test_that("DESCRPTION is read by default", {
   wd <- getwd()
   on.exit(setwd(wd), add = TRUE)

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -60,6 +60,13 @@ test_that("can read object from named character vector", {
   expect_equal(desc$get("BugReports"), new_desc$get("BugReports"))
 })
 
+test_that("partially named vectors passed to 'text' fail", {
+  expect_snapshot(
+    error = TRUE,
+    description$new(text = c(foo = "bar", "baz"))
+  )
+})
+
 test_that("DESCRPTION is read by default", {
   wd <- getwd()
   on.exit(setwd(wd), add = TRUE)


### PR DESCRIPTION
Text argument in creation functions now accepts named vectors. (E.g. `desc::desc(text = c(foo = "bar"))`)

Also:
- Updated documentation
- Added two tests -- one for successful creation and one to verify error when elements are partially named