### PR TITLE
Ignore comments when parsing DCF fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 * `desc_coerce_authors_at_r()` now works correctly for authors with
   multiple given names.
 
+* Ignore comment lines (starting with `#`) in DCF fields (#172, @etiennebacher).
+
 # desc 1.4.3
 
 * `$set()` and `desc_set()` now can omit checks if `check = FALSE`

--- a/R/read.R
+++ b/R/read.R
@@ -1,6 +1,6 @@
 read_dcf <- function(file) {
   lines <- readLines(file)
-  lines <- lines[!grepl("^\\s+#", lines, useBytes = TRUE)]
+  lines <- lines[!grepl("^\\s*#", lines, useBytes = TRUE)]
 
   con <- textConnection(lines, local = TRUE)
   fields <- colnames(read.dcf(con))

--- a/R/read.R
+++ b/R/read.R
@@ -1,5 +1,6 @@
 read_dcf <- function(file) {
   lines <- readLines(file)
+  lines <- lines[!grepl("^\\s+#", lines, perl = TRUE, useBytes = TRUE)]
 
   con <- textConnection(lines, local = TRUE)
   fields <- colnames(read.dcf(con))

--- a/R/read.R
+++ b/R/read.R
@@ -1,6 +1,6 @@
 read_dcf <- function(file) {
   lines <- readLines(file)
-  lines <- lines[!grepl("^\\s+#", lines, perl = TRUE, useBytes = TRUE)]
+  lines <- lines[!grepl("^\\s+#", lines, useBytes = TRUE)]
 
   con <- textConnection(lines, local = TRUE)
   fields <- colnames(read.dcf(con))

--- a/tests/testthat/D18
+++ b/tests/testthat/D18
@@ -1,0 +1,8 @@
+Package: foo
+# foo
+Version: 1.4.3.9000
+Remotes:
+  # bar
+  user/pkg1,
+  # baz
+  user/pkg2

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -41,3 +41,14 @@ test_that("Empty DESCRIPTION", {
   expect_error(description$new(text = ""), NA)
   expect_error(description$new(text = character()), NA)
 })
+
+test_that("comments are kept out of field values, #164", {
+  desc <- description$new(test_path("D18"))
+
+  expect_equal(
+    desc$get("Remotes"),
+    c(Remotes = "\n  user/pkg1,\n  user/pkg2")
+  )
+  expect_equal(desc$get_remotes(), c("user/pkg1", "user/pkg2"))
+  expect_equal(desc$get_version(), package_version("1.4.3.9000"))
+})

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -43,6 +43,8 @@ test_that("Empty DESCRIPTION", {
 })
 
 test_that("comments are kept out of field values, #164", {
+  # Using comments in DESCRIPTION would error before R 4.6
+  skip_if(getRversion() < "4.6")
   desc <- description$new(test_path("D18"))
 
   expect_equal(


### PR DESCRIPTION
Related to #164. I couldn't build `pak` locally to confirm it works well with this patch.

Tests are skipped for R < 4.6 since comments [were not supported before](https://cran.r-project.org/doc/manuals/r-release/NEWS.html):

> read.dcf() now recognizes lines starting with ‘⁠#⁠’ as comment lines. By Dirk Eddelbuettel, Laurent Gatto and Hugo Gruson. 